### PR TITLE
Update ZWave.py

### DIFF
--- a/scapy/scapy/layers/ZWave.py
+++ b/scapy/scapy/layers/ZWave.py
@@ -118,7 +118,7 @@ class BaseZWave(Packet):
         XByteField("length", None),
         XByteField("dst", 0x02),
     ]
-
+    crc = None
     def post_build(self, p, pay):
         # Switch payload and CRC
         crc = p[-1]


### PR DESCRIPTION
Without this fix, "AttributeError: crc" is thrown when building a package using `bytes(frame)`. You must additionally define the crc field in the class.